### PR TITLE
Fix ant build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -36,7 +36,7 @@
             <zipfileset includes="**/*.class" src="lib/j3dcore.jar" />
             <zipfileset includes="**/*.class" src="lib/j3dutils.jar"/>
             <zipfileset includes="**/*.class" src="lib/vecmath.jar"/>
-            <zipfileset includes="**/*.class" src="lib/jssc.jar"/>
+            <zipfileset src="lib/jssc.jar"/>
         </jar>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -20,6 +20,8 @@
         <javac destdir="out/production/jMAVSim" includeantruntime="false" debug="true">
             <classpath refid="libsclasspath"/>
             <src path="src"/>
+            <src path="jMAVlib/src"/>
+            <src path="la4j/src/main/java"/>
         </javac>
     </target>
 


### PR DESCRIPTION
Adds missing srcdirs to fix javac errors of the type:

    error: package me.drton.jmavlib.geo does not exist